### PR TITLE
Update lock files

### DIFF
--- a/README.org
+++ b/README.org
@@ -8,7 +8,8 @@ For Mac, you need to install configurations somehow.
 
 Bug reports are welcome. Please feel free to [[https://github.com/emacs-twist/examples/issues/new][file an issue]].
 ** Trying out
-If you are using Linux with Nix 2.4 or later installed, you can try out a config inside a sandbox.
+Nix 2.9 is required.
+If you are using Linux, you can try out configs inside a sandbox.
 
 Note: [[file:lib/sandbox.nix][The sandboxing script]] temporarily creates =~/.emacs.d= inside its namespace.
 If you have your Emacs configuration in =~/.config/emacs/= (or =${XDG_CONFIG_HOME}/emacs=), it may leave an empty =~/.emacs.d= directory.

--- a/flake.lock
+++ b/flake.lock
@@ -260,11 +260,11 @@
         "fromElisp": "fromElisp"
       },
       "locked": {
-        "lastModified": 1654258140,
-        "narHash": "sha256-HfZAQfwAPuDrGuiZC1XkUARPP4IwfYJ1jlkZ0R7eyL4=",
+        "lastModified": 1654455982,
+        "narHash": "sha256-Q9BN9WqZeJExEaUFhVRnIfd5vliukcqkhpaJeNi/YEc=",
         "owner": "emacs-twist",
         "repo": "twist.nix",
-        "rev": "3d522a6fcae9b9481d79b95f40d5ed9cae54f00b",
+        "rev": "f626e15c402c63caf0334930b10fdc3ac3f927f3",
         "type": "github"
       },
       "original": {

--- a/profiles/terlar/lock/archive.lock
+++ b/profiles/terlar/lock/archive.lock
@@ -57,6 +57,21 @@
     "packageRequires": {},
     "version": "0.1"
   },
+  "dired-git-info": {
+    "archive": {
+      "narHash": "sha256-jAO2VpVAFfBRmGiT8MJglYUr1TYl2RkvHfsbJsPovRw=",
+      "type": "file",
+      "url": "https://elpa.gnu.org/packages/dired-git-info-0.3.1.el"
+    },
+    "inventory": {
+      "type": "archive",
+      "url": "https://elpa.gnu.org/packages/"
+    },
+    "packageRequires": {
+      "emacs": "25"
+    },
+    "version": "0.3.1"
+  },
   "org-contrib": {
     "archive": {
       "narHash": "sha256-P4l7lnlKuBLKlwIYi40bcNjJEElGfjUBmQisABBl8A8=",
@@ -85,6 +100,22 @@
     },
     "packageRequires": {},
     "version": "1.0.6"
+  },
+  "sml-mode": {
+    "archive": {
+      "narHash": "sha256-Yy8edIthcsRro1UXf4vqQmubqWKhaM9nhaSvgnoxneY=",
+      "type": "file",
+      "url": "https://elpa.gnu.org/packages/sml-mode-6.10.el"
+    },
+    "inventory": {
+      "type": "archive",
+      "url": "https://elpa.gnu.org/packages/"
+    },
+    "packageRequires": {
+      "cl-lib": "0.5",
+      "emacs": "24.3"
+    },
+    "version": "6.10"
   },
   "spinner": {
     "archive": {

--- a/profiles/terlar/lock/flake.lock
+++ b/profiles/terlar/lock/flake.lock
@@ -640,22 +640,6 @@
         "type": "github"
       }
     },
-    "dired-git-info": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1577647788,
-        "narHash": "sha256-M75kskJ2Gx1AllWGcbgsj4Kf6MT2myJ7z2oRXdKOJLc=",
-        "owner": "emacsmirror",
-        "repo": "dired-git-info",
-        "rev": "91d57e3a4c5104c66a3abc18e281ee55e8979176",
-        "type": "github"
-      },
-      "original": {
-        "owner": "emacsmirror",
-        "repo": "dired-git-info",
-        "type": "github"
-      }
-    },
     "dired-hacks-utils": {
       "flake": false,
       "locked": {
@@ -3516,7 +3500,6 @@
         "defrepeater": "defrepeater",
         "devdocs": "devdocs",
         "diff-hl": "diff-hl",
-        "dired-git-info": "dired-git-info",
         "dired-hacks-utils": "dired-hacks-utils",
         "dired-sidebar": "dired-sidebar",
         "dired-subtree": "dired-subtree",
@@ -3707,7 +3690,6 @@
         "slime": "slime",
         "sly": "sly",
         "smartparens": "smartparens",
-        "sml-mode": "sml-mode",
         "source-peek": "source-peek",
         "spark": "spark",
         "spray": "spray",
@@ -3971,22 +3953,6 @@
       "original": {
         "owner": "Fuco1",
         "repo": "smartparens",
-        "type": "github"
-      }
-    },
-    "sml-mode": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1606834874,
-        "narHash": "sha256-ZeYZJhsMF4OO9qBUtXTkzDEY/T73XjR4LGIlQt+ozAs=",
-        "owner": "emacsmirror",
-        "repo": "sml-mode",
-        "rev": "1460c3fa0df4464d15fe95bb2039d5ed739381d8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "emacsmirror",
-        "repo": "sml-mode",
         "type": "github"
       }
     },

--- a/profiles/terlar/lock/flake.nix
+++ b/profiles/terlar/lock/flake.nix
@@ -242,12 +242,6 @@
       repo = "diff-hl";
       type = "github";
     };
-    dired-git-info = {
-      flake = false;
-      owner = "emacsmirror";
-      repo = "dired-git-info";
-      type = "github";
-    };
     dired-hacks-utils = {
       flake = false;
       owner = "Fuco1";
@@ -1376,12 +1370,6 @@
       flake = false;
       owner = "Fuco1";
       repo = "smartparens";
-      type = "github";
-    };
-    sml-mode = {
-      flake = false;
-      owner = "emacsmirror";
-      repo = "sml-mode";
       type = "github";
     };
     source-peek = {


### PR DESCRIPTION
Now single-file archives are included. Nix 2.9 is required, so it may be better to wait for weeks or so. 