### PR TITLE
Turn off native compilation of packages

### DIFF
--- a/lib/profile.nix
+++ b/lib/profile.nix
@@ -23,6 +23,7 @@ with builtins; let
       inherit emacsPackage;
       inherit lockDir;
       inherit extraPackages;
+      nativeCompileAheadDefault = false;
       inventories =
         [
           {


### PR DESCRIPTION
Native-compiling every package just for running a demo has little gain, while it adds up the time required to initially start Emacs. I will turn off native compilation here.