### PR TITLE
Delete the checks after updating

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -45,13 +45,3 @@ jobs:
         title: 'chore: Update dependencies'
         branch: create-pull-request/update
         labels: automation,update
-
-  check-terlar:
-    needs: ['update']
-    if: ${{ needs.update.outputs.updated == 'true' }}
-    uses: emacs-twist/examples/.github/workflows/check-terlar.yml@create-pull-request/update
-
-  check-scimax:
-    needs: ['update']
-    if: ${{ needs.update.outputs.updated == 'true' }}
-    uses: emacs-twist/examples/.github/workflows/check-scimax.yml@create-pull-request/update


### PR DESCRIPTION
The workflow calls have caused syntax errors. It assumes `create-pull-request/update` branch has been already created, but the branch is supposed to be created during this workflow, so without an external action, it would not work. I will delete the check steps.