### PR TITLE
Use GNU/nonGNU-devel ELPA

### DIFF
--- a/lib/inputs.nix
+++ b/lib/inputs.nix
@@ -1,19 +1,5 @@
 {lib}:
 with builtins; {
-  dired-subtree = _: super: {
-    packageRequires =
-      super.packageRequires
-      // {
-        dired-hacks-utils = "0";
-      };
-  };
-  dired-hacks-utils = _: super: {
-    packageRequires =
-      super.packageRequires
-      // {
-        dash = "0";
-      };
-  };
   ghelp = _: super: {
     packageRequires =
       super.packageRequires
@@ -23,14 +9,6 @@ with builtins; {
         eglot = "0";
         geiser = "0";
       };
-  };
-  indium = _: _: {
-    origin = {
-      type = "github";
-      owner = "akirak";
-      repo = "Indium";
-      ref = "fix-build-error";
-    };
   };
   counsel = _: super: {
     files = removeAttrs super.files [
@@ -81,36 +59,6 @@ with builtins; {
         slime = "0";
       };
   };
-  org-babel-eval-in-repl = _: super: {
-    files = removeAttrs super.files [
-      "eval-in-repl-ess.el"
-      # "eval-in-repl-matlab.el"
-    ];
-  };
-  request = _: super: {
-    packageRequires =
-      super.packageRequires
-      // {
-        deferred = "0";
-      };
-  };
-  ess = _: super: {
-    files = removeAttrs super.files [".dir-locals.el"];
-  };
-  org-radiobutton = _: super: {
-    packageRequires =
-      super.packageRequires
-      // {
-        dash = "2";
-      };
-  };
-  smartparens = _: super: {
-    packageRequires =
-      {
-        dash = "2";
-      }
-      // super.packageRequires;
-  };
   suggest = _: super: {
     packageRequires =
       super.packageRequires
@@ -131,21 +79,7 @@ with builtins; {
     # le-js depends on indium, which I don't want to install.
     files = builtins.removeAttrs super.files ["le-js.el"];
   };
-  js2-refactor = _: super: {
-    packageRequires =
-      {
-        dash = "0";
-        yasnippet = "0";
-        s = "0";
-        multiple-cursors = "0";
-        js2-mode = "0";
-      }
-      // super.packageRequires;
-  };
   helm = _: super: {
-    files = removeAttrs super.files [".dir-locals.el"];
-  };
-  ghub = _: super: {
     files = removeAttrs super.files [".dir-locals.el"];
   };
   emacsql = _: super: {

--- a/lib/inputs.nix
+++ b/lib/inputs.nix
@@ -32,6 +32,17 @@ with builtins; {
       ref = "fix-build-error";
     };
   };
+  counsel = _: super: {
+    files = removeAttrs super.files [
+      "elpa.el"
+      "ivy-avy.el"
+      "ivy-faces.el"
+      "ivy-hydra.el"
+      "ivy-overlay.el"
+      "ivy.el"
+      "swiper.el"
+    ];
+  };
   rustic = _: super: {
     packageRequires =
       {

--- a/lib/inventories.nix
+++ b/lib/inventories.nix
@@ -29,13 +29,13 @@ inputs: [
   }
   {
     type = "archive";
-    url = "https://elpa.gnu.org/packages/";
+    url = "https://elpa.gnu.org/devel/";
   }
   # Duplicate attribute set for the locked packages, but would be no
   # problem in functionality.
   {
     type = "archive";
-    url = "https://elpa.nongnu.org/nongnu/";
+    url = "https://elpa.nongnu.org/nongnu-devel/";
   }
   {
     name = "emacsmirror";

--- a/profiles/scimax/default.nix
+++ b/profiles/scimax/default.nix
@@ -118,6 +118,7 @@ in {
           request = "0";
         }
         // super.packageRequires;
+      files = removeAttrs super.files ["openalex.el"];
     };
     drag-stuff = _: super: {
       files = removeAttrs super.files ["drag-stuff-pkg.el"];

--- a/profiles/scimax/lock/archive.lock
+++ b/profiles/scimax/lock/archive.lock
@@ -1,30 +1,30 @@
 {
   "peg": {
     "archive": {
-      "narHash": "sha256-dUg+kDdziNVRo773qr8jRkeCa0vjlIsgBJ6WoMhBGDs=",
+      "narHash": "sha256-CXGwZW0ZHZOYjB1qa9pczRE3OH54k/5RfYSAikVHCoI=",
       "type": "tarball",
-      "url": "https://elpa.gnu.org/packages/peg-1.0.1.tar"
+      "url": "https://elpa.gnu.org/devel/peg-1.0.1.0.20221221.81502.tar"
     },
     "inventory": {
       "type": "archive",
-      "url": "https://elpa.gnu.org/packages/"
+      "url": "https://elpa.gnu.org/devel/"
     },
     "packageRequires": {
       "emacs": "25"
     },
-    "version": "1.0.1"
+    "version": "1.0.1.0.20221221.81502"
   },
   "rainbow-mode": {
     "archive": {
-      "narHash": "sha256-Qd5M2ellyZW+UPAxUarkS6s5dv4k3xyTpJtMmKTH9Ug=",
+      "narHash": "sha256-FPlS7DO/Yf7dHUkkpkiGWooJg0oWhKe56go7EYb1Iiw=",
       "type": "tarball",
-      "url": "https://elpa.gnu.org/packages/rainbow-mode-1.0.6.tar"
+      "url": "https://elpa.gnu.org/devel/rainbow-mode-1.0.6.0.20221221.81735.tar"
     },
     "inventory": {
       "type": "archive",
-      "url": "https://elpa.gnu.org/packages/"
+      "url": "https://elpa.gnu.org/devel/"
     },
     "packageRequires": {},
-    "version": "1.0.6"
+    "version": "1.0.6.0.20221221.81735"
   }
 }

--- a/profiles/scimax/lock/flake.lock
+++ b/profiles/scimax/lock/flake.lock
@@ -288,22 +288,6 @@
         "type": "github"
       }
     },
-    "deferred": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1504272644,
-        "narHash": "sha256-ceg2jMNRYsfRNfUDK9viBWlZSvGErPz0euC7eypN5W8=",
-        "owner": "kiwanami",
-        "repo": "emacs-deferred",
-        "rev": "2239671d94b38d92e9b28d4e12fd79814cfb9c16",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kiwanami",
-        "repo": "emacs-deferred",
-        "type": "github"
-      }
-    },
     "diminish": {
       "flake": false,
       "locked": {
@@ -1333,7 +1317,6 @@
         "ctable": "ctable",
         "dash": "dash",
         "dashboard": "dashboard",
-        "deferred": "deferred",
         "diminish": "diminish",
         "drag-stuff": "drag-stuff",
         "elfeed": "elfeed",

--- a/profiles/scimax/lock/flake.nix
+++ b/profiles/scimax/lock/flake.nix
@@ -110,12 +110,6 @@
       repo = "emacs-dashboard";
       type = "github";
     };
-    deferred = {
-      flake = false;
-      owner = "kiwanami";
-      repo = "emacs-deferred";
-      type = "github";
-    };
     diminish = {
       flake = false;
       owner = "myrjola";

--- a/profiles/terlar/lock/archive.lock
+++ b/profiles/terlar/lock/archive.lock
@@ -1,71 +1,71 @@
 {
   "adaptive-wrap": {
     "archive": {
-      "narHash": "sha256-AnDqA7uYSRiLMVAKzw0S2bV+QMagbGxgy38paPaUN4o=",
+      "narHash": "sha256-ZlXIz5zjjI8WaK3ZjnMIGF8z5WI2u/dwycDSaVaw06g=",
       "type": "tarball",
-      "url": "https://elpa.gnu.org/packages/adaptive-wrap-0.8.tar"
+      "url": "https://elpa.gnu.org/devel/adaptive-wrap-0.8.0.20210602.91446.tar"
     },
     "inventory": {
       "type": "archive",
-      "url": "https://elpa.gnu.org/packages/"
+      "url": "https://elpa.gnu.org/devel/"
     },
     "packageRequires": {},
-    "version": "0.8"
+    "version": "0.8.0.20210602.91446"
   },
   "bbdb": {
     "archive": {
-      "narHash": "sha256-3kkU51Xd1nmPgAzwf4S95m6eZ9w15aLCDdVei6ZIJ7o=",
+      "narHash": "sha256-B9y1Ubd9tfQhpb9EwZ0jzfHeslRyvIdP10phrbX7hp0=",
       "type": "tarball",
-      "url": "https://elpa.gnu.org/packages/bbdb-3.2.2.2.tar"
+      "url": "https://elpa.gnu.org/devel/bbdb-3.2.2.2.0.20220705.233849.tar"
     },
     "inventory": {
       "type": "archive",
-      "url": "https://elpa.gnu.org/packages/"
+      "url": "https://elpa.gnu.org/devel/"
     },
     "packageRequires": {
       "cl-lib": "0.5",
       "emacs": "24"
     },
-    "version": "3.2.2.2"
+    "version": "3.2.2.2.0.20220705.233849"
   },
   "csv-mode": {
     "archive": {
-      "narHash": "sha256-m2BrVFt3HIiy8RNLdL52jvyt4lDzB7hmJQ8cGwBE9wY=",
+      "narHash": "sha256-JRYPtot9jWbsAvAKxJ+K1VYtCkc9Trj+Ude+luE1y+0=",
       "type": "tarball",
-      "url": "https://elpa.gnu.org/packages/csv-mode-1.22.tar"
+      "url": "https://elpa.gnu.org/devel/csv-mode-1.22.0.20230208.161318.tar"
     },
     "inventory": {
       "type": "archive",
-      "url": "https://elpa.gnu.org/packages/"
+      "url": "https://elpa.gnu.org/devel/"
     },
     "packageRequires": {
       "cl-lib": "0.5",
       "emacs": "27.1"
     },
-    "version": "1.22"
+    "version": "1.22.0.20230208.161318"
   },
   "cycle-quotes": {
     "archive": {
-      "narHash": "sha256-kLKvs9anXuLEqCkuR8hF9XWBtMvMeCFNcabOOI/RXrY=",
+      "narHash": "sha256-20Wz1BNqX2F1mRVWOGcj+svGYODjg9dyzIn4TBgZuEc=",
       "type": "tarball",
-      "url": "https://elpa.gnu.org/packages/cycle-quotes-0.1.tar"
+      "url": "https://elpa.gnu.org/devel/cycle-quotes-0.1.0.20221221.75021.tar"
     },
     "inventory": {
       "type": "archive",
-      "url": "https://elpa.gnu.org/packages/"
+      "url": "https://elpa.gnu.org/devel/"
     },
     "packageRequires": {},
-    "version": "0.1"
+    "version": "0.1.0.20221221.75021"
   },
   "eglot": {
     "archive": {
-      "narHash": "sha256-U3AZEuiwAll1JUhBO00MKU+E1K+7/9Pn36yBgI0GyHg=",
+      "narHash": "sha256-p77U3nYcd7QY/X+yf0KXM+w0yz5VkY97uk1Mm08QTjI=",
       "type": "tarball",
-      "url": "https://elpa.gnu.org/packages/eglot-1.11.tar"
+      "url": "https://elpa.gnu.org/devel/eglot-1.11.0.20230305.53015.tar"
     },
     "inventory": {
       "type": "archive",
-      "url": "https://elpa.gnu.org/packages/"
+      "url": "https://elpa.gnu.org/devel/"
     },
     "packageRequires": {
       "eldoc": "1.11.0",
@@ -77,7 +77,7 @@
       "seq": "2.23",
       "xref": "1.4.0"
     },
-    "version": "1.11"
+    "version": "1.11.0.20230305.53015"
   },
   "org-contrib": {
     "archive": {
@@ -97,47 +97,48 @@
   },
   "python": {
     "archive": {
-      "narHash": "sha256-mXH3Wcu/la7Vudnpxa34xJNNlO/1owD+NIu50DFt1yk=",
+      "narHash": "sha256-LphsQirHHFZ8j2bA1r2nx0EDW2wTc5v5xRalHA9bub8=",
       "type": "tarball",
-      "url": "https://elpa.gnu.org/packages/python-0.28.tar"
+      "url": "https://elpa.gnu.org/devel/python-0.28.0.20230308.224331.tar"
     },
     "inventory": {
       "type": "archive",
-      "url": "https://elpa.gnu.org/packages/"
+      "url": "https://elpa.gnu.org/devel/"
     },
     "packageRequires": {
-      "cl-lib": "1.0",
-      "emacs": "24.4"
+      "compat": "28.1.2.1",
+      "emacs": "24.4",
+      "seq": "2.23"
     },
-    "version": "0.28"
+    "version": "0.28.0.20230308.224331"
   },
   "rainbow-mode": {
     "archive": {
-      "narHash": "sha256-Qd5M2ellyZW+UPAxUarkS6s5dv4k3xyTpJtMmKTH9Ug=",
+      "narHash": "sha256-FPlS7DO/Yf7dHUkkpkiGWooJg0oWhKe56go7EYb1Iiw=",
       "type": "tarball",
-      "url": "https://elpa.gnu.org/packages/rainbow-mode-1.0.6.tar"
+      "url": "https://elpa.gnu.org/devel/rainbow-mode-1.0.6.0.20221221.81735.tar"
     },
     "inventory": {
       "type": "archive",
-      "url": "https://elpa.gnu.org/packages/"
+      "url": "https://elpa.gnu.org/devel/"
     },
     "packageRequires": {},
-    "version": "1.0.6"
+    "version": "1.0.6.0.20221221.81735"
   },
   "sml-mode": {
     "archive": {
-      "narHash": "sha256-EgX9D+3bKxmAxKPD/dKq8nTS9mmk3YbdpapSNnBticg=",
+      "narHash": "sha256-iHqnoYyM6u7owyg4m3nazr4xGsCA9NC/tF8yCSRP5BI=",
       "type": "tarball",
-      "url": "https://elpa.gnu.org/packages/sml-mode-6.11.tar"
+      "url": "https://elpa.gnu.org/devel/sml-mode-6.11.0.20230127.190610.tar"
     },
     "inventory": {
       "type": "archive",
-      "url": "https://elpa.gnu.org/packages/"
+      "url": "https://elpa.gnu.org/devel/"
     },
     "packageRequires": {
       "cl-lib": "0.5",
       "emacs": "24.3"
     },
-    "version": "6.11"
+    "version": "6.11.0.20230127.190610"
   }
 }

--- a/profiles/terlar/lock/flake.lock
+++ b/profiles/terlar/lock/flake.lock
@@ -576,22 +576,6 @@
         "type": "github"
       }
     },
-    "deferred": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1504272644,
-        "narHash": "sha256-ceg2jMNRYsfRNfUDK9viBWlZSvGErPz0euC7eypN5W8=",
-        "owner": "kiwanami",
-        "repo": "emacs-deferred",
-        "rev": "2239671d94b38d92e9b28d4e12fd79814cfb9c16",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kiwanami",
-        "repo": "emacs-deferred",
-        "type": "github"
-      }
-    },
     "defrepeater": {
       "flake": false,
       "locked": {
@@ -3430,7 +3414,6 @@
         "dash": "dash",
         "deadgrep": "deadgrep",
         "default-text-scale": "default-text-scale",
-        "deferred": "deferred",
         "defrepeater": "defrepeater",
         "devdocs": "devdocs",
         "diff-hl": "diff-hl",

--- a/profiles/terlar/lock/flake.nix
+++ b/profiles/terlar/lock/flake.nix
@@ -218,12 +218,6 @@
       repo = "default-text-scale";
       type = "github";
     };
-    deferred = {
-      flake = false;
-      owner = "kiwanami";
-      repo = "emacs-deferred";
-      type = "github";
-    };
     defrepeater = {
       flake = false;
       owner = "alphapapa";


### PR DESCRIPTION
They contain newer versions of packages, so some issues have been fixed. It's more recommended than their corresponding non-devel versions of the registries.